### PR TITLE
Extract-refs / Supplementary Material

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ build.xml
 */maven-build.xml
 maven-build.xml
 release.properties
+grobid-home
+clients/

--- a/Stylesheets/Bibliography.xsl
+++ b/Stylesheets/Bibliography.xsl
@@ -1461,6 +1461,9 @@
                         <xsl:apply-templates select="person-group"/>
                         <xsl:apply-templates select="elocation-id"/>
                         <xsl:apply-templates select="pub-id"/>
+                        <!-- This is where PLoS put URLs for references -->
+                        <xsl:apply-templates select="comment/ext-link"/>
+                        <xsl:apply-templates select="ext-link"/>
                     </analytic>
                     <monogr>
                         <xsl:apply-templates select="source"/>

--- a/Stylesheets/Bibliography.xsl
+++ b/Stylesheets/Bibliography.xsl
@@ -427,7 +427,8 @@
         <xsl:choose>
             <xsl:when test="note">
                 <bibl type="note">
-                    <xsl:apply-templates/>
+                    <xsl:attribute name="xml:id" select="@id"/>
+                    <xsl:value-of select="."/>
                 </bibl>
             </xsl:when>
             <xsl:otherwise>

--- a/Stylesheets/Bibliography.xsl
+++ b/Stylesheets/Bibliography.xsl
@@ -1417,6 +1417,11 @@
                         <xsl:text>in-line</xsl:text>
                     </xsl:attribute>
                     <xsl:choose>
+                        <xsl:when test="ancestor::ref[@id]">
+                            <xsl:attribute name="xml:id">
+                                <xsl:value-of select="ancestor::ref/@id"/>
+                            </xsl:attribute>
+                        </xsl:when>
                         <xsl:when test="@id">
                             <xsl:attribute name="xml:id">
                                 <xsl:value-of select="@id"/>
@@ -1439,9 +1444,9 @@
                         </xsl:attribute>
                     </xsl:if>
                     <xsl:choose>
-                        <xsl:when test="../../ref[@id]">
+                        <xsl:when test="ancestor::ref[@id]">
                             <xsl:attribute name="xml:id">
-                                <xsl:value-of select="../@id"/>
+                                <xsl:value-of select="ancestor::ref/@id"/>
                             </xsl:attribute>
                         </xsl:when>
                         <xsl:when test="@id">

--- a/Stylesheets/NLM2TEI-article.xsl
+++ b/Stylesheets/NLM2TEI-article.xsl
@@ -1200,6 +1200,7 @@
                         <!-- SG - source des book-reviews, données qualifiés de production chez Cambridge -->
                         <xsl:apply-templates select="front/article-meta/product"/>
                         <xsl:apply-templates select="back/* | bm/ack | bm/bibl"/>
+                        <xsl:apply-templates select="front/article-meta/supplementary-material"/>
 <!--                        <xsl:apply-templates select="sec[@sec-type='supplementary-material'] | notes[@notes-type='supplementary-material']"/>-->
                         <xsl:apply-templates select="front/article-meta/custom-meta-group/custom-meta[@id='data-availability']"/>
                     </back>
@@ -2743,6 +2744,27 @@
         </xsl:if>
     </xsl:template>
 
+    <xsl:template match="supplementary-material[parent::article-meta]">
+<!--        <xsl:message>Processing supplementary-material under article-meta</xsl:message>-->
+        <div type="supplementary-material">
+            <head>Supplementary Material</head>
+            <xsl:if test="@xlink:href">
+                <ref>
+                    <xsl:attribute name="target"><xsl:value-of select="@xlink:href"/></xsl:attribute>
+                    <xsl:if test="@mimetype">
+                        <xsl:attribute name="mimeType"><xsl:value-of select="@mimetype"/></xsl:attribute>
+                    </xsl:if>
+                    <xsl:if test="@xlink:href">
+                        <xsl:attribute name="mimeSubType"><xsl:value-of select="@mime-subtype"/></xsl:attribute>
+                    </xsl:if>
+                </ref>
+                <xsl:if test ="caption">
+                    <xsl:apply-templates select="caption"/>
+                </xsl:if>
+            </xsl:if>
+        </div>
+    </xsl:template>
+
     <xsl:template match="supplementary-material">
         <xsl:variable name="href">
             <xsl:choose>
@@ -2768,9 +2790,18 @@
 
         <xsl:variable name="mimetype" select="@mimetype"/>
 
-        <ref target="{$href}" mimeType="{$mimetype}">
-            <xsl:value-of select="$text"/>
-        </ref>
+        <xsl:choose>
+            <xsl:when test="p/ext-link">
+                <p>
+                    <xsl:apply-templates select="p/ext-link"/>
+                </p>
+            </xsl:when>
+            <xsl:otherwise>
+                <ref target="{$href}" mimeType="{$mimetype}">
+                    <xsl:value-of select="$text"/>
+                </ref>
+            </xsl:otherwise>
+        </xsl:choose>
         <xsl:apply-templates select="caption"/>
     </xsl:template>
 
@@ -2783,11 +2814,18 @@
 <!--        </xsl:apply-templates>-->
 <!--    </xsl:template>-->
 
-    <xsl:template match="sec[@sec-type='supplementary-material'] | notes[@notes-type='supplementary-material']">
-        <div type="supplementary-material">
-            <xsl:apply-templates/>
-        </div>
-    </xsl:template>
+    <!--
+     TODO: Discussion. Why is there such a broad XSLT match as: sec[not(parent::boxed-text)] above?
+      It is an ambiguous rule with the one below. PLoS-XML (at least) puts this below body.
+      So I introduced a restriction on sec[not(parent::boxed-text)] above. Perhaps this is a candidate for
+      kermit2:master?
+     -->
+        <xsl:template priority="2" match="sec[@sec-type='supplementary-material'] | notes[@notes-type='supplementary-material']">
+<!--            <xsl:message>Processing sec-type/note-type supplementary-material</xsl:message>&ndash;&gt;-->
+            <div type="supplementary-material">
+                <xsl:apply-templates/>
+            </div>
+        </xsl:template>
 
 <!--    <xsl:template match="back">-->
 <!--        <xsl:param name="supplementary-content"/>-->
@@ -3055,7 +3093,7 @@
     <xsl:template match="front/article-meta/product">
         <div type="review-of">
             <bibl>
-        <xsl:apply-templates/>
+                <xsl:apply-templates/>
             </bibl>
         </div>
     </xsl:template>


### PR DESCRIPTION
These are 2 sets of changes:
1) Extracting more links from the article
2) Finding more supplementary material sections and details about those sections.

I will try and find the files that made me make these changes so I can illustrate how they help.
We can consider it WIP until then.

Here is a file that illustrates the change in references to accomodate notes with id's:
[note_in_references.zip](https://github.com/user-attachments/files/18803320/note_in_references.zip)

This branch should be merged before a subsequent branch adding SI's when found in the body/sub-articles:
https://github.com/lfoppiano/Pub2TEI/pull/8